### PR TITLE
Replace Object metadata with a Map of metadata properties

### DIFF
--- a/src/main/java/io/vlingo/xoom/symbio/Metadata.java
+++ b/src/main/java/io/vlingo/xoom/symbio/Metadata.java
@@ -7,22 +7,33 @@
 
 package io.vlingo.xoom.symbio;
 
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
 
 public class Metadata implements Comparable<Metadata> {
+  @Deprecated
   public final static Object EmptyObject = new Object() { @Override public String toString() { return "(empty)"; } };
 
+  // Object is deprecated and will be removed in future versions. Use the Map of properties instead.
+  @Deprecated
   public final Object object;
+  public final Map<String, String> properties;
   public final String operation;
   public final String value;
 
   public static Metadata nullMetadata() {
-    return new Metadata(EmptyObject, "", "");
+    return new Metadata(Collections.emptyMap(), "", "");
   }
 
+  @Deprecated
   public static Metadata withObject(final Object object) {
     return new Metadata(object, "", "");
+  }
+
+  public static Metadata withProperties(final Map<String, String> properties) {
+    return new Metadata(properties, "", "");
   }
 
   public static Metadata withOperation(final String operation) {
@@ -34,24 +45,53 @@ public class Metadata implements Comparable<Metadata> {
   }
 
   public static Metadata with(final String value, final String operation) {
-    return new Metadata(EmptyObject, value, operation);
+    return new Metadata(value, operation);
   }
 
+  public static Metadata with(final Map<String, String> properties, final String value, final String operation) {
+    return new Metadata(properties, value, operation);
+  }
+
+  public static Metadata with(final Map<String, String> properties, final String value, final Class<?> operationType) {
+    return with(properties, value, operationType, true);
+  }
+
+  public static Metadata with(final Map<String, String> properties, final String value, final Class<?> operationType, final boolean compact) {
+    final String operation = compact ? operationType.getSimpleName() : operationType.getName();
+    return new Metadata(properties, value, operation);
+  }
+
+  @Deprecated
   public static Metadata with(final Object object, final String value, final String operation) {
     return new Metadata(object, value, operation);
   }
 
+  @Deprecated
   public static Metadata with(final Object object, final String value, final Class<?> operationType) {
     return with(object, value, operationType, true);
   }
 
+  @Deprecated
   public static Metadata with(final Object object, final String value, final Class<?> operationType, final boolean compact) {
     final String operation = compact ? operationType.getSimpleName() : operationType.getName();
     return new Metadata(object, value, operation);
   }
 
+  @Deprecated
   public Metadata(final Object object, final String value, final String operation) {
     if (object == null) this.object = EmptyObject; else this.object = object;
+
+    if (value == null) this.value = ""; else this.value = value;
+
+    if (operation == null) this.operation = ""; else this.operation = operation;
+
+    this.properties = Collections.emptyMap();
+  }
+
+  public Metadata(final Map<String, String> properties, final String value, final String operation) {
+    this.object = EmptyObject;
+
+    if (properties == null) this.properties = Collections.emptyMap(); else this.properties = properties;
 
     if (value == null) this.value = ""; else this.value = value;
 
@@ -59,15 +99,20 @@ public class Metadata implements Comparable<Metadata> {
   }
 
   public Metadata(final String value, final String operation) {
-    this(EmptyObject, value, operation);
+    this(Collections.emptyMap(), value, operation);
   }
 
   public Metadata() {
-    this(EmptyObject, "", "");
+    this(Collections.emptyMap(), "", "");
   }
 
+  @Deprecated
   public boolean hasObject() {
     return object != EmptyObject;
+  }
+
+  public boolean hasProperties() {
+    return !properties.isEmpty();
   }
 
   public boolean hasOperation() {
@@ -82,10 +127,12 @@ public class Metadata implements Comparable<Metadata> {
     return !hasOperation() && !hasValue();
   }
 
+  @Deprecated
   public Object object() {
     return object;
   }
 
+  @Deprecated
   public Optional<Object> optionalObject() {
     return hasObject() ? Optional.of(object) : Optional.empty();
   }
@@ -98,6 +145,7 @@ public class Metadata implements Comparable<Metadata> {
     return value;
   }
 
+  @Deprecated
   @SuppressWarnings("unchecked")
   public <T> T typedObject() {
     return (T) object;
@@ -106,6 +154,7 @@ public class Metadata implements Comparable<Metadata> {
   @Override
   public int compareTo(final Metadata other) {
     if (!this.object.equals(other.object)) return 1;
+    if (!this.properties.equals(other.properties)) return 1;
     return Comparator
             .comparing((Metadata m) -> m.value)
             .thenComparing(m -> m.operation)
@@ -114,7 +163,7 @@ public class Metadata implements Comparable<Metadata> {
 
   @Override
   public int hashCode() {
-    return 31 * value.hashCode() + operation.hashCode() + object.hashCode();
+    return 31 * value.hashCode() + operation.hashCode() + properties.hashCode() + object.hashCode();
   }
 
   @Override
@@ -127,12 +176,13 @@ public class Metadata implements Comparable<Metadata> {
 
     return value.equals(otherMetadata.value) &&
             operation.equals(otherMetadata.operation) &&
+            properties.equals(otherMetadata.properties) &&
             object.equals(otherMetadata.object);
   }
 
   @Override
   public String toString() {
     return getClass().getSimpleName() +
-            "[value=" + value + " operation=" + operation + " object=" + object + "]";
+            "[value=" + value + " operation=" + operation + " properties=" + properties + " object=" + object + "]";
   }
 }

--- a/src/test/java/io/vlingo/xoom/symbio/MetadataTest.java
+++ b/src/test/java/io/vlingo/xoom/symbio/MetadataTest.java
@@ -13,6 +13,10 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class MetadataTest {
 
   @Test
@@ -20,14 +24,37 @@ public class MetadataTest {
     final Metadata metadata = new Metadata();
     assertFalse(metadata.hasValue());
     assertFalse(metadata.hasOperation());
+    assertFalse(metadata.hasProperties());
   }
 
   @Test
+  public void testNullMetadata() {
+    final Metadata metadata = Metadata.nullMetadata();
+    assertFalse(metadata.hasValue());
+    assertFalse(metadata.hasOperation());
+    assertFalse(metadata.hasProperties());
+  }
+
+  @Test
+  @Deprecated
   public void testMetadataObject() {
     final Object object = new Object();
     final Metadata metadata = Metadata.withObject(object);
     assertTrue(metadata.hasObject());
     assertEquals(object, metadata.object);
+    assertFalse(metadata.hasValue());
+    assertFalse(metadata.hasOperation());
+  }
+
+  @Test
+  public void testMetadataProperties() {
+    final Map<String, String> properties = new HashMap<String, String>() {{
+      put("prop1", "value1");
+      put("prop2", "value2");
+    }};
+    final Metadata metadata = Metadata.withProperties(properties);
+    assertTrue(metadata.hasProperties());
+    assertEquals(properties, metadata.properties);
     assertFalse(metadata.hasValue());
     assertFalse(metadata.hasOperation());
   }
@@ -55,5 +82,44 @@ public class MetadataTest {
     assertEquals("value", metadata.value);
     assertTrue(metadata.hasOperation());
     assertEquals("op", metadata.operation);
+  }
+
+  @Test
+  public void testMetadataPropertiesValueOperation() {
+    final Map<String, String> properties = new HashMap<String, String>() {{
+      put("prop1", "value1");
+      put("prop2", "value2");
+    }};
+    final Metadata metadata = Metadata.with(properties, "value", "op");
+    assertTrue(metadata.hasProperties());
+    assertEquals(properties, metadata.properties);
+    assertTrue(metadata.hasValue());
+    assertEquals("value", metadata.value);
+    assertTrue(metadata.hasOperation());
+    assertEquals("op", metadata.operation);
+  }
+
+  @Test
+  public void testMetadataWithClassOperationType() {
+    final Map<String, String> properties = Collections.singletonMap("prop1", "value1");
+    final Metadata metadata = Metadata.with(properties, "value", MetadataTest.class);
+    assertTrue(metadata.hasProperties());
+    assertEquals(properties, metadata.properties);
+    assertTrue(metadata.hasValue());
+    assertEquals("value", metadata.value);
+    assertTrue(metadata.hasOperation());
+    assertEquals("MetadataTest", metadata.operation);
+  }
+
+  @Test
+  public void testMetadataWithNonCompactClassOperationType() {
+    final Map<String, String> properties = Collections.singletonMap("prop1", "value1");
+    final Metadata metadata = Metadata.with(properties, "value", MetadataTest.class, false);
+    assertTrue(metadata.hasProperties());
+    assertEquals(properties, metadata.properties);
+    assertTrue(metadata.hasValue());
+    assertEquals("value", metadata.value);
+    assertTrue(metadata.hasOperation());
+    assertEquals("io.vlingo.xoom.symbio.MetadataTest", metadata.operation);
   }
 }


### PR DESCRIPTION
Serialization has not worked properly with Object(s). The problem has resurfaced when trying to implement Jackson-based serialization. In past, we discussed replacing the Object with a Map of properties.

I have added the Map of properties and deprecated the Object to be removed in future versions.